### PR TITLE
all: adds image deploy support for kubernetes

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -65,7 +65,7 @@ func setupSidecar(dockerClient *docker.Client, config Config) (*docker.Sidecar, 
 	}
 	err = sideCar.UploadToPrimaryContainer(context.Background(), config.InputFile)
 	if err != nil {
-		fatalf("failed to upload input file: %v", err)
+		return nil, fmt.Errorf("failed to upload input file: %v", err)
 	}
 	return sideCar, nil
 }

--- a/deploy.go
+++ b/deploy.go
@@ -139,14 +139,14 @@ func inspect(dockerClient *docker.Client, image string, filesystem Filesystem, w
 		}
 		break
 	}
-	m := map[string]interface{}{
-		"image":     imgInspect,
-		"tsuruYaml": tsuruYaml,
-		"procfile":  procfile,
+	m := tsuru.InspectData{
+		TsuruYaml: tsuruYaml,
+		Image:     imgInspect,
+		Procfile:  procfile,
 	}
 	err = json.NewEncoder(w).Encode(m)
 	if err != nil {
-		return fmt.Errorf("failed to encode inspected data: %v", err)
+		return fmt.Errorf("failed to encode inspected data %v: %v", m, err)
 	}
 	return nil
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/tsuru/deploy-agent/internal/docker"
+	"github.com/tsuru/deploy-agent/internal/docker/testing"
+	"github.com/tsuru/deploy-agent/internal/tsuru"
+	"github.com/tsuru/tsuru/exec"
+	"gopkg.in/check.v1"
+)
+
+const primaryImage = "tsuru/base-platform"
+
+func checkSkip(c *check.C) {
+	if os.Getenv("DEPLOYAGENT_INTEGRATION") == "" {
+		c.Skip("skipping integration tests")
+	}
+}
+
+func (s *S) TestInspect(c *check.C) {
+	checkSkip(c)
+
+	dClient, err := docker.NewClient("")
+	c.Assert(err, check.IsNil)
+
+	_, cleanup, err := testing.SetupPrimaryContainer(c)
+	defer cleanup()
+
+	sidecar, err := docker.NewSidecar(dClient, "root")
+	c.Assert(err, check.IsNil)
+
+	outW := new(bytes.Buffer)
+	errW := new(bytes.Buffer)
+
+	yamlData := `
+hooks:
+  build:
+    - ps
+`
+
+	err = sidecar.Execute(exec.ExecuteOptions{
+		Cmd:    "/bin/sh",
+		Args:   []string{"-c", fmt.Sprintf("mkdir -p /home/application/current/ && echo '%s' > /home/application/current/tsuru.yaml", yamlData)},
+		Stdout: outW,
+		Stderr: errW,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(outW.String(), check.DeepEquals, "")
+	c.Assert(errW.String(), check.DeepEquals, "")
+
+	for _, loc := range []string{"/", "/app/user/", "/home/application/current/"} {
+		outW.Reset()
+		errW.Reset()
+
+		err = sidecar.ExecuteAsUser("root", exec.ExecuteOptions{
+			Cmd:    "/bin/sh",
+			Args:   []string{"-c", fmt.Sprintf(`mkdir -p %s && echo '%s' > %sProcfile`, loc, loc, loc)},
+			Stdout: outW,
+			Stderr: errW,
+		})
+		c.Assert(err, check.IsNil)
+		c.Assert(outW.String(), check.DeepEquals, "")
+		c.Assert(errW.String(), check.DeepEquals, "")
+
+		outW.Reset()
+		errW.Reset()
+
+		err = inspect(dClient, "tsuru/base-platform", &executorFS{executor: sidecar}, outW, errW)
+		c.Assert(err, check.IsNil)
+
+		m := struct {
+			Procfile  string
+			TsuruYaml tsuru.TsuruYaml
+			Image     docker.ImageInspect
+		}{}
+		err = json.NewDecoder(outW).Decode(&m)
+		c.Assert(err, check.IsNil)
+		c.Assert(outW.String(), check.DeepEquals, "")
+		c.Assert(m.Procfile, check.DeepEquals, loc+"\n")
+		c.Assert(m.TsuruYaml, check.DeepEquals, tsuru.TsuruYaml{Hooks: tsuru.Hook{BuildHooks: []string{"ps"}}})
+		c.Assert(m.Image.ID, check.Not(check.DeepEquals), "")
+	}
+
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -38,6 +38,8 @@ type Image struct {
 	tag        string
 }
 
+type ImageInspect docker.Image
+
 func (i Image) Name() string {
 	return i.registry + "/" + i.repository
 }
@@ -139,6 +141,14 @@ func (c *Client) Upload(ctx context.Context, containerID, path string, inputStre
 		InputStream: inputStream,
 	}
 	return c.api.UploadToContainer(containerID, opts)
+}
+
+func (c *Client) Inspect(ctx context.Context, img string) (ImageInspect, error) {
+	inspect, err := c.api.InspectImage(img)
+	if err != nil {
+		return ImageInspect{}, err
+	}
+	return ImageInspect(*inspect), err
 }
 
 func splitImageName(imageName string) (registry, repo, tag string) {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -183,3 +183,15 @@ func (s *S) TestClientUpload(c *check.C) {
 	err = client.api.DownloadFromContainer(contID, docker.DownloadFromContainerOptions{Path: "/myfile.txt"})
 	c.Assert(err, check.IsNil)
 }
+
+func (s *S) TestInspect(c *check.C) {
+	client, err := NewClient(s.dockerserver.URL())
+	c.Assert(err, check.IsNil)
+
+	err = client.api.PullImage(docker.PullImageOptions{Repository: "image"}, docker.AuthConfiguration{})
+	c.Assert(err, check.IsNil)
+
+	img, err := client.Inspect(context.Background(), "image")
+	c.Assert(err, check.IsNil)
+	c.Assert(img.ID, check.Not(check.DeepEquals), "")
+}

--- a/internal/docker/testing/sidecar.go
+++ b/internal/docker/testing/sidecar.go
@@ -1,0 +1,70 @@
+package testing
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+	"gopkg.in/check.v1"
+)
+
+const primaryImage = "tsuru/base-platform"
+
+func SetupPrimaryContainer(c *check.C) (string, func(), error) {
+	dClient, err := docker.NewClient("unix:///var/run/docker.sock")
+	if err != nil {
+		return "", nil, err
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting hostname: %v", err)
+	}
+
+	err = dClient.PullImage(docker.PullImageOptions{Repository: primaryImage}, docker.AuthConfiguration{})
+	if err != nil {
+		return "", nil, fmt.Errorf("error pulling image %v: %v", primaryImage, err)
+	}
+
+	pCont, err := dClient.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image: primaryImage,
+			Cmd:   []string{"/bin/sh", "-lc", "while true; do sleep 10; done"},
+			Labels: map[string]string{
+				"io.kubernetes.container.name": hostname,
+				"io.kubernetes.pod.name":       hostname,
+			},
+		},
+	})
+
+	if err != nil {
+		return "", nil, fmt.Errorf("error creating primary container: %v", err)
+	}
+
+	cleanup := func() {
+		dClient.RemoveContainer(docker.RemoveContainerOptions{ID: pCont.ID, Force: true})
+	}
+
+	err = dClient.StartContainer(pCont.ID, nil)
+	if err != nil {
+		return pCont.ID, cleanup, fmt.Errorf("error starting primary container: %v", err)
+	}
+
+	timeout := time.After(time.Second * 15)
+	for {
+		c, err := dClient.InspectContainer(pCont.ID)
+		if err != nil {
+			return pCont.ID, cleanup, fmt.Errorf("error inspecting primary container: %v", err)
+		}
+		if c.State.Running {
+			break
+		}
+		select {
+		case <-time.After(time.Second):
+		case <-timeout:
+			return pCont.ID, cleanup, fmt.Errorf("timeout waiting for primary container to run")
+		}
+	}
+
+	return pCont.ID, cleanup, nil
+}

--- a/internal/tsuru/client.go
+++ b/internal/tsuru/client.go
@@ -15,8 +15,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tsuru/deploy-agent/internal/docker"
 	"github.com/tsuru/tsuru/app/bind"
 )
+
+type InspectData struct {
+	Image     docker.ImageInspect
+	TsuruYaml interface{}
+	Procfile  string
+}
 
 type TsuruYaml struct {
 	Hooks       Hook                   `json:"hooks,omitempty"`


### PR DESCRIPTION
This commit adds support for sidecar image deployment. When SOURCE_IMAGE
is provided, the sidecar will inspect the given image and also
a potential Procfile and tsuru.yaml on the primary container. This is
sent to stdout so tsuru API can parse and process them.

The primary container is commited and it's image is pushed.