### PR TITLE
internal/docker: fix executor with quoted envs

### DIFF
--- a/internal/docker/executor.go
+++ b/internal/docker/executor.go
@@ -36,7 +36,7 @@ func (d *Executor) ExecuteAsUser(user string, opts exec.ExecuteOptions) error {
 	if len(opts.Envs) > 0 {
 		var exports []string
 		for _, e := range opts.Envs {
-			exports = append(exports, fmt.Sprintf("export %s && ", e))
+			exports = append(exports, fmt.Sprintf("export %q && ", e))
 		}
 		cmd = append(cmd[:2], fmt.Sprintf("%s %s", strings.Join(exports, ""), strings.Join(cmd[2:], " ")))
 	}

--- a/internal/docker/integration_test.go
+++ b/internal/docker/integration_test.go
@@ -124,6 +124,34 @@ func (s *S) TestSidecarExecuteIntegration(c *check.C) {
 			Dir:         "$MYDIR",
 			expectedOut: "/etc\n",
 		},
+		{
+			Name:        "env-with-quotes-non-bash",
+			Cmd:         "echo",
+			Args:        []string{"$MYENV"},
+			Envs:        []string{"MYENV={\"a\": \"b\", \"a2\": \"b2\"}"},
+			expectedOut: "{\"a\": \"b\", \"a2\": \"b2\"}\n",
+		},
+		{
+			Name:        "env-with-quotes",
+			Cmd:         "/bin/sh",
+			Args:        []string{"-lc", "echo $MYENV"},
+			Envs:        []string{"MYENV={\"a\": \"b\", \"a2\": \"b2\"}"},
+			expectedOut: "{\"a\": \"b\", \"a2\": \"b2\"}\n",
+		},
+		{
+			Name:        "env-with-quotes-non-bash",
+			Cmd:         "echo",
+			Args:        []string{"$MYENV"},
+			Envs:        []string{"MYENV={'a': 'b', 'a2': 'b2'}"},
+			expectedOut: "{'a': 'b', 'a2': 'b2'}\n",
+		},
+		{
+			Name:        "env-with-quotes",
+			Cmd:         "/bin/sh",
+			Args:        []string{"-lc", "echo $MYENV"},
+			Envs:        []string{"MYENV={'a': 'b', 'a2': 'b2'}"},
+			expectedOut: "{'a': 'b', 'a2': 'b2'}\n",
+		},
 	}
 
 	for _, t := range tt {

--- a/internal/docker/integration_test.go
+++ b/internal/docker/integration_test.go
@@ -102,13 +102,6 @@ func (s *S) TestSidecarExecuteIntegration(c *check.C) {
 			expectedOut: "myval\n",
 		},
 		{
-			Name:        "env-non-bash",
-			Cmd:         "echo",
-			Args:        []string{"$MYENV"},
-			Envs:        []string{"MYENV=myval", "ANOTHERENV=anotherval"},
-			expectedOut: "myval\n",
-		},
-		{
 			Name:        "dir-env",
 			Cmd:         "/bin/sh",
 			Args:        []string{"-lc", "pwd"},
@@ -125,25 +118,11 @@ func (s *S) TestSidecarExecuteIntegration(c *check.C) {
 			expectedOut: "/etc\n",
 		},
 		{
-			Name:        "env-with-quotes-non-bash",
-			Cmd:         "echo",
-			Args:        []string{"$MYENV"},
-			Envs:        []string{"MYENV={\"a\": \"b\", \"a2\": \"b2\"}"},
-			expectedOut: "{\"a\": \"b\", \"a2\": \"b2\"}\n",
-		},
-		{
 			Name:        "env-with-quotes",
 			Cmd:         "/bin/sh",
 			Args:        []string{"-lc", "echo $MYENV"},
 			Envs:        []string{"MYENV={\"a\": \"b\", \"a2\": \"b2\"}"},
 			expectedOut: "{\"a\": \"b\", \"a2\": \"b2\"}\n",
-		},
-		{
-			Name:        "env-with-quotes-non-bash",
-			Cmd:         "echo",
-			Args:        []string{"$MYENV"},
-			Envs:        []string{"MYENV={'a': 'b', 'a2': 'b2'}"},
-			expectedOut: "{'a': 'b', 'a2': 'b2'}\n",
 		},
 		{
 			Name:        "env-with-quotes",


### PR DESCRIPTION
Prior to this change, the docker executor would fail to run commands 
when a quoted environment was present. Resulting in errors such as:

/bin/sh: 1: export: abc,: bad variable name

This change properly quotes the environment value string fixing the
underlying issue.