### PR TITLE
Extract tsuru.yaml from docker context

### DIFF
--- a/pkg/build/buildkit/testdata/tsuru-files-from-context/Dockerfile
+++ b/pkg/build/buildkit/testdata/tsuru-files-from-context/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:latest
+
+WORKDIR /tmp
+CMD ["echo", "Hello from Tsuru files from context!"]

--- a/pkg/build/buildkit/testdata/tsuru-files-from-context/Procfile
+++ b/pkg/build/buildkit/testdata/tsuru-files-from-context/Procfile
@@ -1,0 +1,1 @@
+web: my-server --addr 0.0.0.0:${PORT}

--- a/pkg/build/buildkit/testdata/tsuru-files-from-context/tsuru.yaml
+++ b/pkg/build/buildkit/testdata/tsuru-files-from-context/tsuru.yaml
@@ -1,0 +1,6 @@
+healthcheck:
+  path: /healthz
+  interval_seconds: 3
+  timeout_seconds: 1
+  ports:
+  - port: 443


### PR DESCRIPTION
Sometimes users forget do add this ugly line:

``` dockerfile
ADD tsuru.yaml /
```

my suggestion is to auto identify tsuru.yaml from context when user use:

``` shell
tsuru app deploy -a APP --dockerfile .
```