### PR TITLE
feat: add option to detect local CPU architecture for BuildKit

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -58,6 +59,12 @@ var cfg struct {
 	BuildKitAutoDiscoveryKubernetesSetTsuruAppLabels          bool
 	BuildKitAutoDiscoveryKubernetesUseSameNamespaceAsTsuruApp bool
 	DisableCache                                              bool
+
+	// BuildKitDetectCPUArch could be use with caution only on local development
+	// environments where the developer is sure about the architecture
+	// of the BuildKit server and the host machine are the same.
+	// This flag is NOT recommended for production environments.
+	BuildKitDetectCPUArch bool
 }
 
 func main() {
@@ -87,6 +94,7 @@ func main() {
 	flag.DurationVar(&cfg.BuildKitAutoDiscoveryScaleGracefulPeriod, "buildkit-autodiscovery-scale-graceful-period", (2 * time.Hour), "how long time after a build to retain buildkit running")
 
 	flag.BoolVar(&cfg.DisableCache, "disable-cache", false, "Disable BuildKit cache during container image builds")
+	flag.BoolVar(&cfg.BuildKitDetectCPUArch, "buildkit-detect-cpu-arch", getBoolEnvOrDefault("BUILDKIT_DETECT_CPU_ARCH", false), "Whether to detect CPU architecture of the host machine and use it to pass to BuildKit")
 
 	flag.Parse()
 
@@ -160,11 +168,21 @@ func getEnvOrDefault(env, def string) string {
 	return def
 }
 
+func getBoolEnvOrDefault(env string, def bool) bool {
+	if envvar, found := os.LookupEnv(env); found {
+		v, _ := strconv.ParseBool(envvar)
+		return v
+	}
+
+	return def
+}
+
 func newBuildKit() (*buildkit.BuildKit, error) {
 	opts := buildkit.BuildKitOptions{
 		TempDir:                      cfg.BuildkitTmpDir,
 		DiscoverBuildKitClientForApp: cfg.BuildKitAutoDiscovery,
 		DisableCache:                 cfg.DisableCache,
+		DetectCPUArch:                cfg.BuildKitDetectCPUArch,
 	}
 
 	var c *client.Client

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/autodiscovery/k8s.go
+++ b/pkg/build/buildkit/autodiscovery/k8s.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/autodiscovery/k8s_test.go
+++ b/pkg/build/buildkit/autodiscovery/k8s_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/autodiscovery/leaser.go
+++ b/pkg/build/buildkit/autodiscovery/leaser.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/autodiscovery/podNotifier.go
+++ b/pkg/build/buildkit/autodiscovery/podNotifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/build.go
+++ b/pkg/build/buildkit/build.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/build_test.go
+++ b/pkg/build/buildkit/build_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/metrics/metrics.go
+++ b/pkg/build/buildkit/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/scaler/downscaler.go
+++ b/pkg/build/buildkit/scaler/downscaler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/scaler/downscaler_test.go
+++ b/pkg/build/buildkit/scaler/downscaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/scaler/upscaler.go
+++ b/pkg/build/buildkit/scaler/upscaler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/buildkit/scaler/upscaler_test.go
+++ b/pkg/build/buildkit/scaler/upscaler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 package scaler

--- a/pkg/build/fake/build.go
+++ b/pkg/build/fake/build.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/grpc_build_v1/build_service.pb.go
+++ b/pkg/build/grpc_build_v1/build_service.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -11,11 +11,12 @@
 package grpc_build_v1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/build/grpc_build_v1/build_service.proto
+++ b/pkg/build/grpc_build_v1/build_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/grpc_build_v1/build_service_grpc.pb.go
+++ b/pkg/build/grpc_build_v1/build_service_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -12,6 +12,7 @@ package grpc_build_v1
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/build/helpers.go
+++ b/pkg/build/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/helpers_test.go
+++ b/pkg/build/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/metadata/metadata.go
+++ b/pkg/build/metadata/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/server.go
+++ b/pkg/build/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/server_test.go
+++ b/pkg/build/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/build/types.go
+++ b/pkg/build/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/repository/fake/repository.go
+++ b/pkg/repository/fake/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/repository/oci/oci.go
+++ b/pkg/repository/oci/oci.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/repository/oci/oci_test.go
+++ b/pkg/repository/oci/oci_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/util/gzip.go
+++ b/pkg/util/gzip.go
@@ -1,4 +1,4 @@
-// Copyright 2025 tsuru authors. All rights reserved.
+// Copyright 2026 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Add BuildKitDetectCPUArch flag that detects the host machine's CPU architecture and passes it to BuildKit. This is intended for local development environments where the BuildKit server and host machine share the same architecture.