### PR TITLE
feat: add docker-credential-ecr-login to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 FROM alpine:${alpine_version}
 COPY --from=build-stage /go/src/github.com/tsuru/deploy-agent/bin/deploy-agent /usr/local/bin/
 ARG docker_credential_gcr_version=2.1.6
+ARG docker_credential_ecr_login_version=0.12.0
 ARG grpc_health_probe_version=0.4.14
 ARG TARGETARCH
 RUN set -ex \
@@ -20,6 +21,9 @@ RUN set -ex \
     && mv docker-credential-gcr /usr/local/bin/ \
     && docker-credential-gcr version \
     && docker-credential-gcr configure-docker --include-artifact-registry \
+    && curl -fsSL -o /usr/local/bin/docker-credential-ecr-login "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${docker_credential_ecr_login_version}/linux-${TARGETARCH}/docker-credential-ecr-login" \
+    && chmod +x /usr/local/bin/docker-credential-ecr-login \
+    && docker-credential-ecr-login -v \
     && curl -fsSL -o /usr/local/bin/grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${grpc_health_probe_version}/grpc_health_probe-linux-${TARGETARCH}" \
     && chmod +x /usr/local/bin/grpc_health_probe
 EXPOSE 8080


### PR DESCRIPTION
Fixes #53.

Adds the [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper)
(v0.12.0, current latest) to the image, mirroring the existing
`docker-credential-gcr` support. This enables buildkit pushes to Amazon ECR
using ambient AWS credentials (IRSA / instance profile) via the standard docker
`credHelpers` config:

```json
{
  "credHelpers": {
    "123456789012.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
  }
}
```

Notes:

- The binary comes from the official awslabs release bucket, which publishes
  `linux-amd64` and `linux-arm64` paths — matching `${TARGETARCH}` directly,
  so both image platforms built by CI are covered. The build runs
  `docker-credential-ecr-login -v` as a sanity check, like the existing
  `docker-credential-gcr version` call.
- Unlike the GCR block, this intentionally does **not** write a `config.json`
  at build time (`gcr configure-docker` has a fixed set of well-known hosts to
  register; ECR registry hosts are account/region-specific), so the
  `credHelpers` entry is left to the operator's mounted docker config.
- Image pruning on ECR is a separate concern (ECR has no delete-on-manifest
  API compatible with the Distribution protocol); operators typically attach an
  ECR lifecycle policy to the repository prefix.

Validated in production: deploys on an EKS cluster pushing to ECR with IRSA
credentials and the `credHelpers` config above — pushes authenticate with no
static secrets.
